### PR TITLE
Set dry run to empty string

### DIFF
--- a/src/utils/default.ini
+++ b/src/utils/default.ini
@@ -11,11 +11,12 @@ DEFAULT_PROMOTION_DAY = Thursday
 #######################################################
 REPO_PATH = /Volumes/munki_repo_test
 DEBUG_PKGS_INFO_SAVE_PATH = None
-DRY_RUN = False
 
 #######################################################
 # Usually you do NOT need to change the values below
 #######################################################
+# set to any value to enable a dry run
+DRY_RUN =
 CATALOGS_DIR =  catalogs
 PKGS_INFO_DIR = pkgsinfo
 MAKECATALOGS = /usr/local/munki/makecatalogs


### PR DESCRIPTION
The default behaviour is now to run the munkipromoter NOT in dry run
mode instead changes will be committed. To change this any value can be
added in the default config file.
